### PR TITLE
expressatt: fix Wi-Fi not working when not flashed with CWM

### DIFF
--- a/rootdir/etc/wifimac.sh
+++ b/rootdir/etc/wifimac.sh
@@ -1,4 +1,4 @@
-#!/system/bin/sh
+#!/sbin/sh
 
 # Hardcoded sources and destinations based on apexqtmo. Optional
 # commandline parameter to override MACSOURCE in order to specify
@@ -79,6 +79,7 @@ B6_4=$B6a`echo $LOOKUP | cut -c$((IDX+3))`
 
 # The actual edit. Don't trust recovery's busybox to have "-R",
 # use freshly installed busybox on /system/xbin instead.
+export LD_LIBRARY_PATH="/system/lib:$LD_LIBRARY_PATH"
 /system/xbin/busybox hexdump -Cv $NVSOURCE | sed -e "s/^00000000  \(.*\)00 00 00 00 00 00  |/00000000  \1$B1 $B2 $B3 $B4 $B5 $B6_1  |/" | sed -e "s/^00000010  .*  |/00000010  $B1 $B2 $B3 $B4 $B5 $B6_2 $B1 $B2  $B3 $B4 $B5 $B6_3 $B1 $B2 $B3 $B4  |/" | sed -e "s/^00000020  00 03\(.*\)/00000020  $B5 $B6_4\1/" | /system/xbin/busybox hexdump -R > $DEST
 
 if ( $UMOUNTPERSIST ); then


### PR DESCRIPTION
This was due to wifimac.sh calling dynamically-linked executables without setting LD_LIBRARY_PATH, therefore leading the script not to run properly.
This commit changes the hashbang so that it uses the recovery's shell, and sets that variable.
